### PR TITLE
dark-mode-download-toggle-fixed

### DIFF
--- a/src/components/Main/Main.jsx
+++ b/src/components/Main/Main.jsx
@@ -23,8 +23,7 @@ const Main = ({ modeToggle, modeToggleFunc }) =>  {
                   onClick={() => {
                     download(d);
                   }}
-                  className={`${classes.mode_toggle} ${modeToggle ? classes.dark_mode : classes.light_mode}`} onClick={()=>modeToggleFunc(!modeToggle)}
-                >
+                  className={`${classes.mode_toggle} ${modeToggle ? classes.dark_mode : classes.light_mode}`} >
                   Download
                 </button>
               </div>


### PR DESCRIPTION
in the main branch, the download button is working as a dark mode toggle instead of download button. The issue has been fixed in this version