### PR TITLE
Fix broken font import

### DIFF
--- a/public/Buttons/PranavKale03/style.css
+++ b/public/Buttons/PranavKale03/style.css
@@ -1,4 +1,4 @@
-@import url('htpps://fonts.googleapis.com/css?family=Poppins:100,200,300,400,500,600,700,800,900');
+@import url('https://fonts.googleapis.com/css2?family=Poppins&display=swap');
 *{
   margin: 0;
   padding: 0;


### PR DESCRIPTION
Fixes the following error:
GET htpps://fonts.googleapis.com/css?family=Poppins:100,200,300,400,500,600,700,800,900 net::ERR_UNKNOWN_URL_SCHEME

Signed-off-by: Arjun Ingole <arjuningole38@gmail.com>