### PR TITLE
🐛 FIX: INCORRECT NAVIGATIONAL LINK ON README [DOCS]

### DIFF
--- a/README.md
+++ b/README.md
@@ -66,7 +66,7 @@ To contribute to the Animating Buttons repository, follow these steps:
 
 | Step | Description                                                                                                     | Link                                                         |
 |------|-----------------------------------------------------------------------------------------------------------------|--------------------------------------------------------------|
-| 1    | Go to the public/Buttons folder in the repository.                                                              | [public/Buttons](https://github.com/0xabdulkhalid/Animating-Buttons/tree/main/public/Buttons)                   |
+| 1    | Go to the public/Buttons folder in the repository.                                                              | [public/Buttons](https://github.com/Spyware007/Animating-Buttons/tree/main/public/Buttons)                   |
 | 2    | Add a new folder with your GitHub username, including your button code (index.html + style.css files).          | -                                                            |
 | 3    | Go to the src/Data.js file.                                                                                     | [src/Data.js](https://github.com/Spyware007/Animating-Buttons/blob/main/src/Data.js)                                     |
 | 4    | Add your folder name (e.g., `github_username`) and your code in the src/Data.js file.                           | -                                                            |

--- a/README.md
+++ b/README.md
@@ -66,7 +66,7 @@ To contribute to the Animating Buttons repository, follow these steps:
 
 | Step | Description                                                                                                     | Link                                                         |
 |------|-----------------------------------------------------------------------------------------------------------------|--------------------------------------------------------------|
-| 1    | Go to the public/Buttons folder in the repository.                                                              | [public/Buttons](https://github.com/Spyware007/Animating-Buttons/blob/main/src/components/Main/Main.jsx)                   |
+| 1    | Go to the public/Buttons folder in the repository.                                                              | [public/Buttons](https://github.com/0xabdulkhalid/Animating-Buttons/tree/main/public/Buttons)                   |
 | 2    | Add a new folder with your GitHub username, including your button code (index.html + style.css files).          | -                                                            |
 | 3    | Go to the src/Data.js file.                                                                                     | [src/Data.js](https://github.com/Spyware007/Animating-Buttons/blob/main/src/Data.js)                                     |
 | 4    | Add your folder name (e.g., `github_username`) and your code in the src/Data.js file.                           | -                                                            |


### PR DESCRIPTION
### Description:
- Before this PR the navigational link of `public/Buttons` is pointing towards `https://github.com/Spyware007/Animating-Buttons/blob/main/src/components/Main/Main.jsx`
- Now in this PR i resolved the issue and modified the link to `https://github.com/Spyware007/Animating-Buttons/tree/main/public/Buttons`

### This issue is assigned me under GSSoC'23, the Issue: #696


### Reviewer: 
- @Spyware007 
