### PR TITLE
docs: add workflow to close old Pull Request

### DIFF
--- a/.github/workflows/close_old_prs.yml
+++ b/.github/workflows/close_old_prs.yml
@@ -1,0 +1,34 @@
+name: Close Old PRs
+on:
+  # Schedule updates (At minute 0 past every 24th hour)
+  schedule: [{ cron: "0 0 * * *" }]
+
+jobs:
+  close-old-prs:
+    runs-on: ubuntu-latest
+
+    steps:
+      - name: Checkout Repository
+        uses: actions/checkout@v2
+
+      - name: Close Old PRs
+        run: |
+          open_prs=$(curl -s -H "Authorization: token ${{ secrets.GITHUB_TOKEN }}" \
+            "https://api.github.com/repos/${{ github.repository }}/pulls?state=open" \
+            | jq -r '.[] | .number')
+
+          for pr in $open_prs; do
+            # Get the last updated timestamp of the pull request
+            last_updated=$(curl -s -H "Authorization: token ${{ secrets.GITHUB_TOKEN }}" \
+              "https://api.github.com/repos/${{ github.repository }}/pulls/$pr" \
+              | jq -r '.updated_at')
+
+            days_since_update=$(( ( $(date +%s) - $(date -d "$last_updated" +%s) ) / 86400 ))
+
+            if [ $days_since_update -gt 30 ]; then
+              curl -s -X PATCH -H "Authorization: token ${{ secrets.GITHUB_TOKEN }}" \
+                -H "Accept: application/vnd.github.v3+json" \
+                -d '{"state":"closed"}' \
+                "https://api.github.com/repos/${{ github.repository }}/pulls/$pr"
+            fi
+          done


### PR DESCRIPTION
## Fixes Issue

Closes #1045 

## Working of the workflow

- The workflow is triggered on a schedule using a `cron` expression. In this case, it is set to run every day at midnight (0 0 * * *).

- The workflow job named `close-old-prs` runs on the latest version of the Ubuntu environment.

- The steps within the job are as follows:
   - "Checkout Repository" step: This step checks out the repository's code, allowing subsequent actions to access its contents.
   - "Close Old PRs" step: This step contains the main logic to close old PRs. Here's what it does:
      - It makes a GET request to the GitHub API to retrieve a list of open PRs in the repository.
      - For each open PR, it retrieves the last updated timestamp using another API request.
      - It calculates the number of days that have passed since the last update of the PR.

- If the number of days since the last update is greater than `30`, it makes a PATCH request to the GitHub API to close the PR by updating its state to `closed`.

- The workflow utilizes the `secrets.GITHUB_TOKEN` secret, which is a token provided by GitHub to authenticate and authorize API requests made by the workflow.

Overall, this workflow helps automate the process of closing old PRs in a GitHub repository by checking their last update timestamp and closing them if they have been inactive for more than 30 days.

## Checklist

- [x] You've linked this PR to the correct issue.
- [x] You have checked that the code is working correctly.
- [x] You ⭐️ the repository!

## Note to reviewers

<!-- List anything note-worthy here (potential issues, PR #25 needs to be merged to before working, etc.). -->
