### PR TITLE
docs: add workflow to close issues

### DIFF
--- a/.github/workflows/close_old_issues.yml
+++ b/.github/workflows/close_old_issues.yml
@@ -1,0 +1,34 @@
+name: Close Old Issues
+on:
+  # Schedule updates (At minute 0 past every 24th hour)
+  schedule: [{ cron: "0 0 * * *" }]
+
+jobs:
+  close-issues:
+    runs-on: ubuntu-latest
+
+    steps:
+      - name: Checkout Repository
+        uses: actions/checkout@v2
+
+      - name: Close Old Issues
+        run: |
+          open_issues=$(curl -s -H "Authorization: token ${{ secrets.GITHUB_TOKEN }}" \
+            "https://api.github.com/repos/${{ github.repository }}/issues?state=open" \
+            | jq -r '.[] | .number')
+
+          for issue in $open_issues; do
+            # Get the last updated timestamp of the issue
+            last_updated=$(curl -s -H "Authorization: token ${{ secrets.GITHUB_TOKEN }}" \
+              "https://api.github.com/repos/${{ github.repository }}/issues/$issue" \
+              | jq -r '.updated_at')
+
+            days_since_update=$(( ( $(date +%s) - $(date -d "$last_updated" +%s) ) / 86400 ))
+
+            if [ $days_since_update -gt 30 ]; then
+              curl -s -X PATCH -H "Authorization: token ${{ secrets.GITHUB_TOKEN }}" \
+                -H "Accept: application/vnd.github.v3+json" \
+                -d '{"state":"closed"}' \
+                "https://api.github.com/repos/${{ github.repository }}/issues/$issue"
+            fi
+          done


### PR DESCRIPTION
## Fixes Issue

Closes #1046

## Working

1. The workflow is triggered on a schedule using a `cron` expression. In this case, it is set to run every day at midnight `(0 0 * * *)`.

2. The workflow job named `close-issues` runs on the latest version of the Ubuntu environment.

3. The steps within the job are as follows:

   a. "Checkout Repository" step: This step checks out the repository's code, allowing subsequent actions to access its contents.

   b. "Close Old Issues" step: This step contains the main logic to close old issues. Here's what it does:

      - It makes a `GET` request to the GitHub API to retrieve a list of open issues in the repository.

      - For each open issue, it retrieves the last updated timestamp using another API request.

      - It calculates the number of days that have passed since the last update of the issue.

4. If the number of days since the last update is greater than `30`, it makes a PATCH request to the GitHub API to close the issue by updating its state to "closed".

```yml
if [ $days_since_update -gt 30 ]; then
```

The workflow utilizes the `secrets.GITHUB_TOKEN` secret, which is a token provided by GitHub to authenticate and authorize API requests made by the workflow.

Overall, this workflow helps automate the process of closing old issues in a GitHub repository by checking their last update timestamp and closing them if they have been inactive for more than `30` days.

## Checklist

- [x] You've linked this PR to the correct issue.
- [x] You have checked that the code is working correctly.
- [x] You ⭐️ the repository!

## Note to reviewers

We can also insert a workflow that closes PRs without linked issues if it is relevant to the contributing guidelines. Feel free to share your thoughts regarding this workflow.
