### PR TITLE
Fixed Responsiveness in mobile view

### DIFF
--- a/src/components/Main/Main.module.css
+++ b/src/components/Main/Main.module.css
@@ -113,6 +113,7 @@
   list-style-type: none;
   display: flex;
   gap: 5px;
+  flex-wrap: wrap;
 }
 
 .paginationItem {

--- a/src/components/Top/GoToTop.css
+++ b/src/components/Top/GoToTop.css
@@ -12,8 +12,8 @@ wrapper{
     background-color: rgb(1, 167, 1);
     border-radius: 50%;
     position: fixed;
-    bottom: 5rem;
-    right: 5rem;
+    bottom: 6rem;
+    right: 1rem;
     z-index: 999;
     display: flex;
     justify-content: center;


### PR DESCRIPTION
Adding flex wrap property in Main.module.css fix the overflow of number button and changing css of GoToTop button to make it looks good.

## Screenshots (Before Change)

![before](https://github.com/Spyware007/Animating-Buttons/assets/104075614/8fa947f7-b117-4025-b5af-d436fd8a834b)
 GoToTop button

![before button](https://github.com/Spyware007/Animating-Buttons/assets/104075614/0f6b80c1-7877-4908-b360-c2655cffd528)

## Screenshots (After Change)
![fixed](https://github.com/Spyware007/Animating-Buttons/assets/104075614/e0769f7a-cbec-4fee-b6c4-5c5d292fff93)

for GoToTop button
![after button](https://github.com/Spyware007/Animating-Buttons/assets/104075614/48cb5d32-ad66-4af9-9748-bc1955d0fe9b)



### Please mark it under GSSoc'23