### PR TITLE
[FEAT]: MAKE SOCIAL ANCHORS ACCESSIBLE ON FOOTER ✨

### DIFF
--- a/src/components/Footer/Footer.jsx
+++ b/src/components/Footer/Footer.jsx
@@ -23,13 +23,22 @@ const Footer = ({ modeToggle }) => {
       </div>
       <ul className={classes.footer_right}>
         <li className={classes.footer_icons}>
-          <a className={classes.linkg} href="https://github.com/spyware007">
+          <a 
+            className={classes.linkg}
+            aria-label="Follow me on Github"
+            title="Instagram (External Link)"
+            rel="noopener noreferrer"
+            href="https://github.com/spyware007"
+          >
             <FaGithubSquare className={classes.glow} />
           </a>
         </li>
         <li className={classes.footer_icons_2}>
           <a
             className={classes.linki}
+            aria-label="Follow me on Instagram"
+            title="Instagram (External Link)"
+            rel="noopener noreferrer"
             href="https://www.instagram.com/spyware007_/"
           >
             <FaInstagramSquare className={classes.glow} />
@@ -38,13 +47,22 @@ const Footer = ({ modeToggle }) => {
         <li className={classes.footer_icons}>
           <a
             className={classes.linkl}
+            aria-label="Follow me on Linkedin"
+            title="Instagram (External Link)"
+            rel="noopener noreferrer"
             href="https://www.linkedin.com/in/om-gawande/"
           >
             <FaLinkedin className={classes.glow} />
           </a>
         </li>
         <li className={classes.footer_icons_2}>
-          <a className={classes.linkt} href="https://twitter.com/oom_gawande">
+          <a 
+            className={classes.linkt} 
+            aria-label="Follow me on Twitter"
+            title="Instagram (External Link)"
+            rel="noopener noreferrer"
+            href="https://twitter.com/oom_gawande"
+          >
             <FaTwitterSquare className={classes.glow} />
           </a>
         </li>


### PR DESCRIPTION
## Fixes Issue

Closes #1693 

## Changes proposed

- Added `aria-label` attribute for social anchors like github & twitter
- The `aria-label` attribute is important for screen readers because it provides a text label for an object, such as `a` with social icons. When a screen reader encounters the object, the `aria-label` text is read so that the user will know what it is. 
- This is important for people who are blind or have low vision, as they rely on screen readers to access the web.
- Improved `title` attribute's data, because the title attribute is intended to provide additional information to screen reader users.
- And along with that i added `rel` for the anchors which are lacking them to ensure best practices for crawlers
- Because adding the `rel="noopener noreferrer"` attribute can help to protect this website from security vulnerabilities and improve performance. It is a good practice to use this attribute on all external links.
- Overall this PR is intended to make necessary changes to meet best practices for crawlers along with improving accessibility for social anchors

## Screenshots

- We can't take screenshots of accessibility changes rather than code changes, Accessibility changes are often invisible to the user because it's intended to guide disabled people

## Checklist
- [x] You've linked this PR to the correct issue.
- [x] You have checked that the code is working correctly.
- [x] You ⭐️ the repository!