### PR TITLE
Updated hover state of show and download buttons.

### DIFF
--- a/src/components/common/Button/Button.module.css
+++ b/src/components/common/Button/Button.module.css
@@ -50,10 +50,10 @@
 .light-Btn
 .tooltipl {
   position: absolute;
-  left: -202px;
-  top: -301px;
-  width: 280px;
-  height: 280px;
+  left: -50px;
+  top: -110px;
+  width: 100px;
+  height: 80px;
   opacity: 0;
   color: rgba(12, 12, 12, 0.85);
   background-color: rgb(255, 255, 255);
@@ -80,10 +80,10 @@
 .dark-Btn
 .tooltipl {
   position: absolute;
-  left: -202px;
-  top: -301px;
-  width: 280px;
-  height: 280px;
+  left: -50px;
+  top: -110px;
+  width: 100px;
+  height: 80px;
   opacity: 0;
   background-color: rgba(12, 12, 12, 0.85);
   color: rgb(255, 255, 255);

--- a/src/components/common/Button/Button.module.css
+++ b/src/components/common/Button/Button.module.css
@@ -52,7 +52,7 @@
   position: absolute;
   left: -50px;
   top: -110px;
-  width: 100px;
+  width: 101px;
   height: 80px;
   opacity: 0;
   color: rgba(12, 12, 12, 0.85);
@@ -82,7 +82,7 @@
   position: absolute;
   left: -50px;
   top: -110px;
-  width: 100px;
+  width: 101px;
   height: 80px;
   opacity: 0;
   background-color: rgba(12, 12, 12, 0.85);


### PR DESCRIPTION
## Fixes Issue - #1785 

I updated the hover state of buttons in which when previously hovered it took the whole card to show its functionality but I reduced it's size so that the user can see the button and it will be visible all the time.

Please review my changes and add it to the main branch. @Spyware007 